### PR TITLE
make pmodel hashable

### DIFF
--- a/kin/stellar/horizon_models.py
+++ b/kin/stellar/horizon_models.py
@@ -19,6 +19,9 @@ class PModel(Model):
 
     def __repr__(self):
         return self.__str__()
+    
+    def __hash__(self):
+        return hash(self.__str__())
 
 
 class AccountData(PModel):

--- a/test/test_horizon.py
+++ b/test/test_horizon.py
@@ -335,3 +335,14 @@ def test_assets(test_sdk):
     # assert reply
     # assert reply['_embedded']['records']
     pass
+
+
+def test_horizon_error_hashable(test_sdk):
+    err_dict = dict(title='title',
+                    status=400,
+                    detail='detail',
+                    instance='instance',
+                    extras={},
+                    type=HORIZON_NS_PREFIX + HorizonErrorType.BAD_REQUEST)
+    e = HorizonError(err_dict)
+    {e: 1}  # shouldn't fail on unhashable type


### PR DESCRIPTION
make pmodel hashable so horizonError is hashable too. Non hashable errors cause weird bugs when raising them.

```
 39 y 03 12:25:27 ip-10-0-5-244 make[30222]: During handling of the above exception, another exception occurred:
 38 y 03 12:25:27 ip-10-0-5-244 make[30222]: Traceback (most recent call last):
 37 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/bin/rq", line 11, in <module>
 36 y 03 12:25:27 ip-10-0-5-244 make[30222]:     sys.exit(main())
 35 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 722, in __call__
 34 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return self.main(*args, **kwargs)
 33 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 697, in main
 32 y 03 12:25:27 ip-10-0-5-244 make[30222]:     rv = self.invoke(ctx)
 31 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 1066, in invoke
 30 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return _process_result(sub_ctx.command.invoke(sub_ctx))
 29 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 895, in invoke
 28 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return ctx.invoke(self.callback, **ctx.params)
 27 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 535, in invoke
 26 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return callback(*args, **kwargs)
 25 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/cli/cli.py", line 73, in wrapper
 24 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return ctx.invoke(func, cli_config, *args[1:], **kwargs)
 23 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 535, in invoke
 22 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return callback(*args, **kwargs)
 21 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/cli/cli.py", line 232, in worker
 20 y 03 12:25:27 ip-10-0-5-244 make[30222]:     worker.work(burst=burst, logging_level=logging_level)
 19 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 495, in work
 18 y 03 12:25:27 ip-10-0-5-244 make[30222]:     self.execute_job(job, queue)
 17 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 659, in execute_job
 16 y 03 12:25:27 ip-10-0-5-244 make[30222]:     self.fork_work_horse(job, queue)
 15 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 601, in fork_work_horse
 14 y 03 12:25:27 ip-10-0-5-244 make[30222]:     self.main_work_horse(job, queue)
 13 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 674, in main_work_horse
 12 y 03 12:25:27 ip-10-0-5-244 make[30222]:     success = self.perform_job(job, queue)
 11 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 805, in perform_job
 10 y 03 12:25:27 ip-10-0-5-244 make[30222]:     self.handle_exception(job, *sys.exc_info())
  9 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 830, in handle_exception
  8 y 03 12:25:27 ip-10-0-5-244 make[30222]:     traceback.format_exception_only(*exc_info[:2]) + traceback.format_exception(*exc_info)
  7 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/lib/python3.5/traceback.py", line 136, in format_exception_only
  6 y 03 12:25:27 ip-10-0-5-244 make[30222]:     return list(TracebackException(etype, value, None).format_exception_only())
  5 y 03 12:25:27 ip-10-0-5-244 make[30222]:   File "/usr/lib/python3.5/traceback.py", line 455, in __init__
  4 y 03 12:25:27 ip-10-0-5-244 make[30222]:     and exc_value.__context__ not in _seen):
  3 y 03 12:25:27 ip-10-0-5-244 make[30222]: TypeError: unhashable type: 'HorizonError'
```