### PR TITLE
create account with trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tx_hash = sdk.create_account('address')
 tx_hash = sdk.create_account('address', starting_balance=1000)
 
 # create a new activated account
-tx_hash = sdk.create_account('address', starting_balance=1000,activate=True)  
+tx_hash = sdk.create_account('address', starting_balance=1000, activate=True)  
 ```
 ### Checking if Account is Activated (Trustline established)
 ```python

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ tx_hash = sdk.create_account('address')
 
 # create a new account prefunded with a specified amount of native currency (lumens).
 tx_hash = sdk.create_account('address', starting_balance=1000)
-```
 
+# create a new activated account
+tx_hash = sdk.create_account('address', starting_balance=1000,activate=True)  
+```
 ### Checking if Account is Activated (Trustline established)
 ```python
 # check if KIN is trusted by some account

--- a/kin/sdk.py
+++ b/kin/sdk.py
@@ -220,7 +220,7 @@ class SDK(object):
         """
         return self._get_account_asset_balance(address, self.kin_asset)
 
-    def create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None):
+    def create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None, activate=False):
         """Create an account identified by the provided address.
 
         :param str address: the address of the account to create.
@@ -229,6 +229,8 @@ class SDK(object):
             MIN_ACCOUNT_BALANCE will be used.
 
         :param str memo_text: (optional) a text to put into transaction memo.
+
+        :param boolean activate: (optional) should the created account be activated
 
         :return: transaction hash
         :rtype: str
@@ -246,7 +248,8 @@ class SDK(object):
         try:
             reply = self.channel_manager.send_transaction(lambda builder:
                                                           partial(builder.append_create_account_op, address,
-                                                                  starting_balance),
+                                                                  starting_balance,trustline=activate,
+                                                                  issuer=self.kin_asset.issuer,asset_code=self.kin_asset.code),
                                                           memo_text=memo_text)
             return reply['hash']
         except Exception as e:

--- a/kin/sdk.py
+++ b/kin/sdk.py
@@ -246,10 +246,10 @@ class SDK(object):
             raise ValueError('invalid address: {}'.format(address))
 
         try:
+            pretrusted_asset = self.kin_asset if activate else None
             reply = self.channel_manager.send_transaction(lambda builder:
                                                           partial(builder.append_create_account_op, address,
-                                                                  starting_balance,trustline=activate,
-                                                                  issuer=self.kin_asset.issuer,asset_code=self.kin_asset.code),
+                                                                  starting_balance, pretrusted_asset=pretrusted_asset),
                                                           memo_text=memo_text)
             return reply['hash']
         except Exception as e:

--- a/kin/stellar/builder.py
+++ b/kin/stellar/builder.py
@@ -69,12 +69,12 @@ class Builder(BaseBuilder):
             self.sequence = self.get_sequence()
         super(Builder, self).sign(secret)
 
-    def append_create_account_op(self, destination, starting_balance, source=None, trustline=False, issuer=None, asset_code=None):
+    def append_create_account_op(self, destination, starting_balance, source=None, pretrusted_asset=None):
         """
-        Alternative implementation that allows to create a trustline in addition to the create accoutn operation
+        Alternative implementation that allows to create a trustline in addition to the create account operation
         Needs to be supported by the blockchain
         """
         super(Builder, self).append_create_account_op(destination, starting_balance,source)
-        if trustline:
+        if pretrusted_asset:
             # Source for the trust op should be the created account
-            super(Builder, self).append_trust_op(issuer,asset_code,source=destination)
+            super(Builder, self).append_trust_op(pretrusted_asset.issuer, pretrusted_asset.code, source=destination)

--- a/kin/stellar/builder.py
+++ b/kin/stellar/builder.py
@@ -68,3 +68,13 @@ class Builder(BaseBuilder):
         if not secret:  # only get the new sequence for my own account
             self.sequence = self.get_sequence()
         super(Builder, self).sign(secret)
+
+    def append_create_account_op(self, destination, starting_balance, source=None, trustline=False, issuer=None, asset_code=None):
+        """
+        Alternative implementation that allows to create a trustline in addition to the create accoutn operation
+        Needs to be supported by the blockchain
+        """
+        super(Builder, self).append_create_account_op(destination, starting_balance,source)
+        if trustline:
+            # Source for the trust op should be the created account
+            super(Builder, self).append_trust_op(issuer,asset_code,source=destination)


### PR DESCRIPTION
This change allows to create an account and activate it at the same time.

the method 'create_account' now has a flag 'activate' that can be set to True to achieve that.

example:
```python
import kin
from stellar_base.network import NETWORKS
from stellar_base.asset import Asset

NETWORKS['RESEARCH'] = 'scaling research'
kin_asset = Asset('KIN','GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A7OIDDTEUYTCJYGY3FJMYIDTU7')

sdk = kin.SDK('seed1',
              channel_secret_keys=['seed2'],
              network='RESEARCH',
              horizon_endpoint_uri='endpoint',
              kin_asset=kin_asset)

sdk.create_account('GDMBKYHJBPUOMULWQBBKQ7I62ZL5XBWXCEIAX5E7747TPFW3SEOG3UUI', starting_balance=30, activate=True)
```

Currently, kin-core-python does not know how to handle errors from transactions with multiple operations, so if this transaction will fail, the returned error will be 'internal error'