### PR TITLE
bump numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ crc16==0.1.1
 ed25519==1.4
 idna==2.6
 mnemonic==0.18
-numpy==1.14.0
+numpy==1.15.2
 pbkdf2==1.3
 requests==2.18.4
 schematics==2.0.1


### PR DESCRIPTION
kin-core-python fails to install on Python 3.7 because of the numpy version in the requirments.txt

Updated numpy version to 1.15.2

relevant issue: https://github.com/numpy/numpy/issues/10500

This change was already merged to the v2-master branch