### PR TITLE
V2 create with trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ account = client.kin_account('seed',channels=number, create_channels=True/False)
 
 # Additionaly, an unique app-id can be provided, this will mark all of your transactions and allow the Kin Ecosystem to track the kin usage of your app
 # A unique app-id should be recivied from the Kin Ecosystem
+# If no app-id is given, an 'anonymous' app-id will be used
 account = client.kin_account('seed',app_id='unique_app_id')
 ```
 
@@ -129,6 +130,20 @@ client.verify_kin_payment('tx_hash','addr1','addr2',15,'Hello',True) >> False
 client.verify_kin_payment('tx_hash','addr1','addr2',15) >> True
 client.verify_kin_payment('tx_hash','addr1','addr2',10) >> False
 client.verify_kin_payment('tx_hash','addr1','addr3',10) >> False
+```
+
+### Getting transaction history
+This method allows you to receive a list of transactions that are related to an account
+```python
+tx_history = client.get_account_transaction_history('address')
+
+# several optional parameters are avilable:
+# simple=(True)/False - Should the the resulting transactions be simplified. A transaction that cannot be simplified will be skipped
+# descending=(True)/False - The order of the transactions
+# cursor=None/Number - A paging token to get a specific transaction list
+
+# Note that currently the maximum amount of tranactions you can get in a single request from the blockchain is 200,
+# if the requested amount is bigger than 200, the function will run recursivly until it got the requested amount
 ```
 
 ### Checking configuration
@@ -210,7 +225,14 @@ tx_hash = account.create_account('address')
 tx_hash = account.create_account('address', starting_balance=1000)
 
 # a text memo can also be provided:
+# the text memo can fit up to 21 bytes of utf-8 text
 tx_hash = account.create_account('address', starting_balance=1000,memo_text='Account creation example')
+
+# Note:
+# By defualt, created accounts are also activated on creation,
+this can be overriden by setting the 'activate' falg to False
+
+tx_hash = account.create_account('address', activate=False)
 ```
 
 ### Sending Currency

--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ tx_data = sdk.get_transaction_data(tx_hash, simple=True/False)
 
 # A transaction will not be simplifed if:
 # 1. It contains a memo that is not a text memo
-# 2. It contains multiple operations
-# 3. It contains a payment that is not of KIN/XLM
-# 4. It contains activation to anything other than KIN
-# 5. Its operation type is not one of 'Payment'/'Activation'/'Create account'.
+# 2. It contains a payment that is not of KIN/XLM
+# 3. It contains activation to anything other than KIN
+# 4. Its operation type is not one of 'Payment'/'Activation'/'Create account'.
 
 # Given the use case of our blockchain, and the tools that we currently provied to interact with it, these conditions should not occur.
 ```

--- a/images/docker-compose.yml
+++ b/images/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   stellar-core-1:
-    image: kinecosystem/stellar-core:9.2.0
+    image: kinecosystem/stellar-core:kinecosystem-v1.0.0-stellar-v9.2.0
     ports:
       - 11626:11626
     links:
@@ -26,7 +26,7 @@ services:
       POSTGRES_DB: core
 
   stellar-core-2:
-    image: kinecosystem/stellar-core:9.2.0
+    image: kinecosystem/stellar-core:kinecosystem-v1.0.0-stellar-v9.2.0
     ports:
       - 11627:11626
     links:
@@ -49,7 +49,7 @@ services:
       POSTGRES_DB: core
 
   horizon:
-    image: kinecosystem/horizon:v0.12.3-control-db-connection-count
+    image: kinecosystem/horizon:v0.12.3-sse-pubsub-performance-improvement
     # using nginx-proxy
     ports:
       - 8000:8000

--- a/kin/account.py
+++ b/kin/account.py
@@ -81,7 +81,7 @@ class KinAccount:
             for channel in self.channel_secret_keys:
                 try:
                     # TODO: might want to make it a 1 multi operation tx
-                    base_account.create_account(Keypair.address_from_seed(channel))
+                    base_account.create_account(Keypair.address_from_seed(channel), activate=False)
                 except KinErrors.AccountExistsError:
                     pass
 
@@ -144,7 +144,7 @@ class KinAccount:
                                                    cursor=None,
                                                    simple=True)
 
-    def create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None):
+    def create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None, activate=True):
         """Create an account identified by the provided address.
 
         :param str address: the address of the account to create.
@@ -154,7 +154,7 @@ class KinAccount:
 
         # TODO: might want to limit this if we use tx_coloring
         :param str memo_text: (optional) a text to put into transaction memo, up to MEMO_CAP chars.
-
+        :param bool activate: (optional) should the created account be activated
         :return: the hash of the transaction
         :rtype: str
 
@@ -162,9 +162,10 @@ class KinAccount:
         :raises: :class:`KinErrors.AccountExistsError`: if the account already exists.
         :raises: :class:`KinErrors.MemoTooLongError`: if the memo is longer than MEMO_CAP characters
         """
+
         tx = self.build_create_account(address,
                                        starting_balance=starting_balance,
-                                       memo_text=memo_text)
+                                       memo_text=memo_text, activate=activate)
         return self.submit_transaction(tx)
 
     def send_xlm(self, address, amount, memo_text=None):
@@ -212,7 +213,8 @@ class KinAccount:
         tx = self._build_send_asset(self._client.kin_asset, address, amount, memo_text)
         return self.submit_transaction(tx)
 
-    def build_create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None):
+    def build_create_account(self, address, starting_balance=MIN_ACCOUNT_BALANCE, memo_text=None,
+                             activate=True):
         """Build a tx that will create an account identified by the provided address.
 
         :param str address: the address of the account to create.
@@ -222,7 +224,7 @@ class KinAccount:
 
         # TODO: might want to limit this if we use tx_coloring
         :param str memo_text: (optional) a text to put into transaction memo, up to MEMO_CAP chars.
-
+        :param bool activate: (optional) should the created account be activated
         :return: a transaction object
         :rtype: :class: `Kin.Transaction`
 
@@ -234,9 +236,11 @@ class KinAccount:
 
         # Build the transaction and send it.
 
+        pretrusted_asset = self._client.kin_asset if activate else None
+
         builder = self.channel_manager.build_transaction(lambda builder:
                                                          partial(builder.append_create_account_op, address,
-                                                                 starting_balance),
+                                                                 starting_balance, kin_asset=pretrusted_asset),
                                                          memo_text=build_memo(self.app_id, memo_text))
         return Transaction(builder, self.channel_manager)
 

--- a/kin/blockchain/builder.py
+++ b/kin/blockchain/builder.py
@@ -59,3 +59,14 @@ class Builder(BaseBuilder):
         if not secret:  # only get the new sequence for my own account
             self.sequence = self.get_sequence()
         super(Builder, self).sign(secret)
+
+    def append_create_account_op(self, destination, starting_balance, source=None, kin_asset=None):
+        """
+        Alternative implementation that allows to create a trustline
+        in addition to the create account operation
+        Needs to be supported by the blockchain
+        """
+        super(Builder, self).append_create_account_op(destination, starting_balance, source)
+        if kin_asset:
+            # Source for the trust op should be the created account
+            super(Builder, self).append_trust_op(kin_asset.issuer, kin_asset.code, source=destination)

--- a/kin/blockchain/errors.py
+++ b/kin/blockchain/errors.py
@@ -90,6 +90,7 @@ class OperationResultCode:
     BAD_AUTH = 'op_bad_auth'
     NO_ACCOUNT = 'op_no_source_account'
     NOT_SUPPORTED = 'op_not_supported'
+    SUCCESS = 'op_success'
 
 
 # noinspection PyClassHasNoInit

--- a/kin/client.py
+++ b/kin/client.py
@@ -251,7 +251,9 @@ class KinClient(object):
         """
 
         tx = self.get_transaction_data(tx_hash)
-        operation = tx.operation
+        if len(tx.operations) > 1:
+            return False
+        operation = tx.operations[0]
         if operation.type != OperationTypes.PAYMENT:
             return False
         if operation.asset != self.kin_asset.code:

--- a/kin/errors.py
+++ b/kin/errors.py
@@ -206,8 +206,11 @@ def translate_transaction_error(tx_error):
 
 def translate_operation_error(op_result_codes):
     """Operation error translator."""
-    # NOTE: we currently handle only one operation per transaction!
-    op_result_code = op_result_codes[0]
+    # NOTE: we show the error for the first failed operation
+    for op in op_result_codes:
+        if op != OperationResultCode.SUCCESS:
+            op_result_code = op
+            break
     if op_result_code == OperationResultCode.BAD_AUTH \
             or op_result_code == CreateAccountResultCode.MALFORMED \
             or op_result_code == PaymentResultCode.NO_ISSUER \

--- a/kin/monitors.py
+++ b/kin/monitors.py
@@ -163,7 +163,6 @@ class MultiMonitor:
                     continue
                 try:
                     tx = json.loads(event.data)
-                    print(tx)
                     try:
                         tx_data = SimplifiedTransaction(RawTransaction(tx), self.kin_client.kin_asset)
                     except CantSimplifyError:

--- a/kin/monitors.py
+++ b/kin/monitors.py
@@ -75,10 +75,10 @@ class SingleMonitor:
                     except CantSimplifyError:
                         continue
 
-                    if tx_data.operation.type != OperationTypes.PAYMENT:
+                    if tx_data.operations[0].type != OperationTypes.PAYMENT:
                         continue
 
-                    if tx_data.operation.asset != self.kin_client.environment.kin_asset.code:
+                    if tx_data.operations[0].asset != self.kin_client.environment.kin_asset.code:
                         continue
 
                     self.callback_fn(self.address, tx_data, self)
@@ -169,16 +169,17 @@ class MultiMonitor:
                     except CantSimplifyError:
                         continue
 
-                    if tx_data.operation.type != OperationTypes.PAYMENT:
+                    print(tx_data.operations[0])
+                    if tx_data.operations[0].type != OperationTypes.PAYMENT:
                         continue
 
-                    if tx_data.operation.asset != self.kin_client.environment.kin_asset.code:
+                    if tx_data.operations[0].asset != self.kin_client.environment.kin_asset.code:
                         continue
 
                     if tx_data.source in self.addresses:
                         self.callback_fn(tx_data.source, tx_data, self)
-                    if tx_data.operation.destination in self.addresses:
-                        self.callback_fn(tx_data.operation.destination, tx_data, self)
+                    if tx_data.operations[0].destination in self.addresses:
+                        self.callback_fn(tx_data.operations[0].destination, tx_data, self)
 
                 except Exception as ex:
                     logger.exception(ex)

--- a/kin/monitors.py
+++ b/kin/monitors.py
@@ -169,7 +169,6 @@ class MultiMonitor:
                     except CantSimplifyError:
                         continue
 
-                    print(tx_data.operations[0])
                     if tx_data.operations[0].type != OperationTypes.PAYMENT:
                         continue
 

--- a/kin/monitors.py
+++ b/kin/monitors.py
@@ -41,10 +41,10 @@ class SingleMonitor:
         # Fix will be for horizon to send any message just to start a connection.
         # This will cause a tx
         params = {}
-        reply = self.kin_client.horizon.account_transactions(address, params={'order': 'desc', 'limit': 2})
-        if len(reply['_embedded']['records']) == 2:
-            cursor = reply['_embedded']['records'][1]['paging_token']
-            params = {'cursor': cursor}
+        reply = self.kin_client.horizon.account_transactions(address, params={'order': 'desc', 'limit': 1})
+        cursor = reply['_embedded']['records'][0]['paging_token']
+        # Decrease the cursor by one to get an immediate response
+        params = {'cursor': str(int(cursor) - 1)}
 
         # make synchronous SSE request (will raise errors in the current thread)
         self.sse_client = self.kin_client.horizon.account_transactions(address, sse=True, params=params)
@@ -135,10 +135,10 @@ class MultiMonitor:
         # Instead, we determine the cursor ourselves.
         # Fix will be for horizon to send any message just to start a connection
         params = {}
-        reply = self.kin_client.horizon.transactions(params={'order': 'desc', 'limit': 2})
-        if len(reply['_embedded']['records']) == 2:
-            cursor = reply['_embedded']['records'][1]['paging_token']
-            params = {'cursor': cursor}
+        reply = self.kin_client.horizon.transactions(params={'order': 'desc', 'limit': 1})
+        cursor = reply['_embedded']['records'][0]['paging_token']
+        # Decrease the cursor by one to get an immediate response
+        params = {'cursor': str(int(cursor) - 1)}
 
         # make synchronous SSE request (will raise errors in the current thread)
         self.sse_client = self.kin_client.horizon.transactions(sse=True, params=params)
@@ -163,7 +163,7 @@ class MultiMonitor:
                     continue
                 try:
                     tx = json.loads(event.data)
-
+                    print(tx)
                     try:
                         tx_data = SimplifiedTransaction(RawTransaction(tx), self.kin_client.kin_asset)
                     except CantSimplifyError:

--- a/kin/transactions.py
+++ b/kin/transactions.py
@@ -67,6 +67,7 @@ class SimplifiedTransaction:
     def __init__(self, raw_tx, kin_asset):
         self.id = raw_tx.hash
         self.timestamp = raw_tx.timestamp
+        self.operations = []
 
         # If the memo is not a text/none memo
         if not isinstance(raw_tx.tx.memo, (TextMemo, NoneMemo)):
@@ -74,9 +75,8 @@ class SimplifiedTransaction:
         self.memo = None if isinstance(raw_tx.tx.memo, NoneMemo) \
             else raw_tx.tx.memo.text.decode() # will be none if the there is no memo
 
-        if len(raw_tx.tx.operations) > 1:
-            raise CantSimplifyError('Cant simplify tx with {} operations'.format(raw_tx.operation_count))
-        self.operation = SimplifiedOperation(raw_tx.tx.operations[0], kin_asset)
+        for operation in raw_tx.tx.operations:
+            self.operations.append(SimplifiedOperation(operation, kin_asset))
 
         # Override tx source with operation source if it exists.
         self.source = raw_tx.tx.operations[0].source or raw_tx.tx.source.decode()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,8 +44,6 @@ def test_account(setup, test_client):
     root_account = test_client.kin_account(setup.issuer_seed)
     root_account.create_account(sdk_address, 10000)
     print('Created the base kin account')
-    test_client.activate_account(sdk_seed)
-    print('Base kin account activated')
     root_account.send_kin(sdk_address, 1000000)
     print('Funded the base kin account')
     return test_client.kin_account(sdk_seed)

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -148,7 +148,8 @@ def test_build_send_kin(test_account):
 def test_auto_top_up(test_client, test_account):
     channel = 'SBYU2EBGTTGIFR4O4K4SQXTD4ISMVX4R5TX2TTB4SWVIA5WVRS2MHN4K'
     public = 'GBKZAXTDJRYBK347KDTOFWEBDR7OW3U67XV2BOF2NLBNEGRQ2WN6HFK6'
-    test_account.create_account(public, starting_balance=3 * BASE_RESERVE + DEFAULT_FEE)
+    test_account.create_account(public, starting_balance=3 * BASE_RESERVE + DEFAULT_FEE, activate=False)
+    test_client.activate_account(channel)
 
     account = test_client.kin_account(test_account.keypair.secret_seed, channel_secret_keys=[channel])
     account.send_kin(public, 10)

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -71,6 +71,10 @@ def test_create_account(test_client, test_account):
 
     test_account.create_account('GDN7KB72OO7G6VBD3CXNRFXVELLW6F36PS42N7ASZHODV7Q5GYPETQ74')
     status = test_client.get_account_status('GDN7KB72OO7G6VBD3CXNRFXVELLW6F36PS42N7ASZHODV7Q5GYPETQ74')
+    assert status == AccountStatus.ACTIVATED
+
+    test_account.create_account('GCDK5QWODFQZLGL53L7RBBERKZW2I7Y6MLYK627P7KVC52RDWFQ5YGV6',activate=False)
+    status = test_client.get_account_status('GCDK5QWODFQZLGL53L7RBBERKZW2I7Y6MLYK627P7KVC52RDWFQ5YGV6')
     assert status == AccountStatus.NOT_ACTIVATED
 
 
@@ -145,7 +149,6 @@ def test_auto_top_up(test_client, test_account):
     channel = 'SBYU2EBGTTGIFR4O4K4SQXTD4ISMVX4R5TX2TTB4SWVIA5WVRS2MHN4K'
     public = 'GBKZAXTDJRYBK347KDTOFWEBDR7OW3U67XV2BOF2NLBNEGRQ2WN6HFK6'
     test_account.create_account(public, starting_balance=3 * BASE_RESERVE + DEFAULT_FEE)
-    test_client.activate_account(channel)
 
     account = test_client.kin_account(test_account.keypair.secret_seed, channel_secret_keys=[channel])
     account.send_kin(public, 10)
@@ -159,9 +162,9 @@ def test_memo(test_client, test_account):
     recipient1 = 'GCT3YLKNVEILHUOZYK3QPOVZWWVLF5AE5D24Y6I4VH7WGZYBFU2HSXYX'
     recipient2 = 'GDR375ZLWHZUFH2SWXFEH7WVPK5G3EQBLXPZKYEFJ5EAW4WE4WIQ5BP3'
 
-    tx1 = test_account.create_account(recipient1, memo_text='Hello')
+    tx1 = test_account.create_account(recipient1, memo_text='Hello', activate=False)
     account2 = test_client.kin_account(test_account.keypair.secret_seed, app_id='test')
-    tx2 = account2.create_account(recipient2, memo_text='Hello')
+    tx2 = account2.create_account(recipient2, memo_text='Hello', activate=False)
     sleep(5)
 
     tx1_data = test_client.get_transaction_data(tx1)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -120,11 +120,11 @@ def test_get_transaction_data(test_client):
     assert tx_data.id == tx_hash
     assert tx_data.timestamp
     assert tx_data.memo is None
-    assert tx_data.operation
+    assert tx_data.operations
     assert tx_data.source == test_client.kin_asset.issuer  # root account
-    assert tx_data.operation.type == OperationTypes.CREATE_ACCOUNT
-    assert tx_data.operation.destination == address
-    assert tx_data.operation.starting_balance == 10
+    assert tx_data.operations[0].type == OperationTypes.CREATE_ACCOUNT
+    assert tx_data.operations[0].destination == address
+    assert tx_data.operations[0].starting_balance == 10
 
     tx_data = test_client.get_transaction_data(tx_hash, simple=False)
     assert isinstance(tx_data, RawTransaction)

--- a/test/test_horizon.py
+++ b/test/test_horizon.py
@@ -175,7 +175,7 @@ def test_transaction(test_client, test_account):
     assert reply
     assert reply['id'] == tx_id
 
-    assert reply['operation_count'] == 1
+    assert reply['operation_count'] == 2
 
 
 def test_transaction_effects(test_client, test_account):

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -66,17 +66,17 @@ def test_multi_monitor(test_client, test_account):
 
     # pay from sdk to the account
     hash1 = test_account.send_kin(address1, 1)
-    sleep(5)
+    sleep(10)
     assert hash1 in txs_found1
 
     hash2 = test_account.send_kin(address2, 2)
-    sleep(5)
+    sleep(10)
     # The second address is not being watched
     assert hash2 not in txs_found2
 
     monitor.add_address(address2)
     hash3 = test_account.send_kin(address2, 3)
-    sleep(5)
+    sleep(10)
     assert hash3 in txs_found2
 
     # stop monitoring


### PR DESCRIPTION
The blockchain team introduced a change to the blockchain that allows an account to create an account that is already trusting kin.

Changes:
1. Ability to create an account with trust (true by default)
2. Can now handle errors from transactions with multiple operations
3. Can now simplify transactions with more than 1 operation
4. Monitors can now handle accounts that only ever had 1 transaction
5. Updated tests and blockchain dockers to the latest version

Docs:
Updated

Tests:
Passing :) , monitors sometimes fail because of a blockchain issue, and the blockchain team are aware