### PR TITLE
V2 new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Python 2 > 2.7.9 / 3 > 3.4
 ## Installation 
 
 ```bash
-pip install git+https://github.com/kinecosystem/kin-core-python.git
-# TODO: add to pypi after PR is done
+pip install kin-sdk
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements-dev.txt') as f:
     tests_requires = [line.split(' ')[0] for line in f]
 
 setup(
-    name='kin',
+    name='kin-sdk',
     version=__version__,
     description='KIN SDK for Python',
     author='Kin Ecosystem',


### PR DESCRIPTION
The "kin" name is already taken 
https://pypi.org/project/kin/

So the name is changed to ```kin-sdk```