### PR TITLE
Create seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,28 +43,19 @@ MY_CUSTOM_ENVIRONMENT = Environemnt('name','horizon endpoint','network passphras
 
 Once you have a KinClient, you can use it to get a KinAccount object: 
 ```python
-# The KinAccount object can be initizlied in a number of ways:
+# The KinAccount object can be initizlied in two ways:
 
 # With a single seed:
 account = client.kin_account('seed')
 
-# With specific channels:
+# With channels:
 account = client.kin_account('seed', channel_secret_keys=['seed1','seed2','seed3'...])
-
-# With deterministic channels
-# This will generate the channels secret seeds for you, based on your primary seed. 
-# The generated channels will always be the same for the same primary seed.
-# If this is your first time using these channels, you should set 'create_channels' to true.
-# This will create the channel account from your primary seed (and will cost 1.6 * number of channels XLM)
-account = client.kin_account('seed',channels=number, create_channels=True/False)
-
-# Every seed can only send one transaction per ledger (~5 seconds),
-# so using channels will greatly increase your concurrency.
 
 # Additionaly, an unique app-id can be provided, this will mark all of your transactions and allow the Kin Ecosystem to track the kin usage of your app
 # A unique app-id should be received from the Kin Ecosystem
 account = client.kin_account('seed',app_id='unique_app_id')
 ```
+Read more about channels in the ["Channels" section](#Channels)
 
 ## Client Usage
 Most methods provided by the KinClient to query the blockchain about a specific account, can also be used from the KinAccount object to query the blockchain about itself
@@ -326,7 +317,8 @@ When you are done monitoring, make sure to stop the monitor, to terminate the th
 monitor.stop()
 ```
 
-## Limitations
+
+## Channels
 
 One of the most sensitive points in Stellar is [transaction sequence](https://www.stellar.org/developers/guides/concepts/transactions.html#sequence-number).
 In order for a transaction to be submitted successfully, this number should be correct. However, if you have several 
@@ -349,6 +341,22 @@ one Flask application is created, containing a single KinAccount instance.
 3. You have a number of load-balanced application servers. Here, each application server should a) have the setup outlined
 above, and b) have its own channel accounts. This way, you ensure you will not have any collisions in your transaction
 sequences.
+
+### Creating Channels
+```
+# The kin sdk allows you to create HD (highly desterministic) channels based on your seed and a passphrase to be used as a salt.
+# As long as you use the same seed and passphrase, you will always get the same seeds.
+
+import kin.utils
+
+channels = utils.create_channels(master_seed, environment, amount, starting_balance, salt)
+
+"channels" will be a list of seeds the sdk created for you, that can be used when initializing the KinAccount object.
+
+# If you just wish to get the list of the channels generated from your seed + passphrase combination without creating them
+
+channels = utils.get_hd_channels(master_seed, salt, amount)
+```
 
 
 ## License

--- a/kin/blockchain/keypair.py
+++ b/kin/blockchain/keypair.py
@@ -59,7 +59,7 @@ class Keypair:
         """
         Generate a highly deterministic seed from a base seed + salt
         :param base_seed: The base seed to generate a seed from
-        :param salt: A uniqe string that will be used to generate the seed
+        :param salt: A unique string that will be used to generate the seed
         :return: a new seed.
         """
         # Create a new raw seed from the first 32 bytes of this hash

--- a/kin/client.py
+++ b/kin/client.py
@@ -37,22 +37,20 @@ class KinClient(object):
         self.horizon = Horizon(horizon_uri=environment.horizon_uri, user_agent=SDK_USER_AGENT)
         logger.info('Kin SDK inited on network {}, horizon endpoint {}'.format(self.network, self.horizon.horizon_uri))
 
-    def kin_account(self, seed, channels=None, channel_secret_keys=None, create_channels=False, app_id=ANON_APP_ID):
+    def kin_account(self, seed, channel_secret_keys=None, app_id=ANON_APP_ID):
         """
         Create a new instance of a KinAccount to perform authenticated operations on the blockchain.
         :param str seed: The secret seed of the account that will be used
-        :param int channels: Number of channels to use
         :param list of str channel_secret_keys: A list of seeds to be used as channels
-        :param boolean create_channels: Should the sdk create the channel accounts
         :param str app_id: the unique id of your app
         :return: An instance of KinAccount
-        :rtype: :class:`kin.KinAccount`
+        :rtype: kin.KinAccount
 
         :raises: :class:`KinErrors.AccountNotFoundError`: if SDK wallet or channel account is not yet created.
         """
 
         # Create a new kin account, using self as the KinClient to be used
-        return KinAccount(seed, self, channels, channel_secret_keys, create_channels, app_id)
+        return KinAccount(seed, self,channel_secret_keys, app_id)
 
     def get_config(self):
         """Get system configuration data and online status.

--- a/kin/utils.py
+++ b/kin/utils.py
@@ -1,0 +1,78 @@
+"""Contains helper methods for the kin sdk"""
+
+from hashlib import sha256
+
+from .client import KinClient
+from .blockchain.builder import Builder
+from .blockchain.keypair import Keypair
+from .errors import AccountNotFoundError
+
+
+def create_channels(master_seed, environment, amount, starting_balance, salt):
+    """
+    Create HD seeds based on a master seed and salt
+    :param str master_seed: The master seed that creates the seeds
+    :param Kin.Environment environment: The blockchain environment to create the seeds on
+    :param int amount: Number of seeds to create (Up to 100)
+    :param float starting_balance: Starting balance to create channels with
+    :param str salt: A string to be used to create the HD seeds
+    :return: The list of seeds generated
+    :rtype list[str]
+    """
+
+    client = KinClient(environment)
+    base_key = Keypair(master_seed)
+    if not client.does_account_exists(base_key.public_address):
+        raise AccountNotFoundError(base_key.public_address)
+
+    fee = client.get_minimum_fee()
+
+    channels = get_hd_channels(master_seed, salt, amount)
+
+    # Create a builder for the transaction
+    builder = Builder(environment.name, client.horizon, fee, master_seed)
+
+    # Find out if this salt+seed combination was ever used to create channels.
+    # If so, the user might only be interested in adding channels,
+    # so we need to find what seed to start from
+
+    for index, seed in enumerate(channels):
+        if client.does_account_exists(Keypair.address_from_seed(seed)):
+            continue
+
+        # Start creating from the current seed forward
+        for channel_seed in channels[index:]:
+            builder.append_create_account_op(Keypair.address_from_seed(channel_seed), str(starting_balance))
+
+        builder.sign()
+        builder.submit()
+        break
+
+    return channels
+
+
+def get_hd_channels(master_seed, salt, amount):
+    """
+    Get a list of channels generated based on a seed and salt
+    :param str master_seed: the base seed that created the channels
+    :param str salt: A string to be used to generate the seeds
+    :param int amount: Number of seeds to generate (Up to 100)
+    :return: The list of seeds generated
+    :rtype list[str]
+    """
+
+    if amount > 100:
+        raise ValueError('Only 100 channels can be created with a specific seed + salt combination')
+    hashed_salt = sha256(salt.encode()).hexdigest()
+
+    channels = []
+    for index in range(amount):
+        # The salt used to generate the
+        channel = Keypair.generate_hd_seed(master_seed, hashed_salt + str(index))
+        channels.append(channel)
+
+    return channels
+
+
+
+

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -37,27 +37,6 @@ def test_create_exisitng_channels(test_client, test_account):
     with pytest.raises(KinErrors.StellarSecretInvalidError):
         account = test_client.kin_account(SDK_SEED, channel_secret_keys=['bad'])
 
-    with pytest.raises(ValueError):
-        account = test_client.kin_account(SDK_SEED, channel_secret_keys=channels, create_channels=True)
-
-    for channel in channels:
-        test_client.friendbot(Keypair.address_from_seed(channel))
-
-    account = test_client.kin_account(SDK_SEED, channel_secret_keys=channels)
-    assert account
-    assert set(channels) == set(account.channel_secret_keys)
-
-
-def test_create_new_channels(test_client, test_account):
-    with pytest.raises(KinErrors.AccountNotFoundError):
-        account = test_client.kin_account(SDK_SEED, channels=2, create_channels=False)
-
-    account = test_client.kin_account(SDK_SEED, channels=4, create_channels=True)
-    assert account
-    assert len(account.channel_secret_keys) == 4
-    for channel in account.channel_secret_keys:
-        assert test_client.does_account_exists(Keypair.address_from_seed(channel))
-
 
 def test_get_address(test_client, test_account):
     assert test_account.get_public_address() == SDK_PUBLIC

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from kin.blockchain.utils import *
+from kin.utils import get_hd_channels, create_channels
 
 
 def test_is_valid_address():
@@ -22,3 +23,14 @@ def test_is_valid_secret_key():
 def test_is_valid_transaction_hash():
     assert not is_valid_transaction_hash('bad')
     assert is_valid_transaction_hash('c2a9d905a728ae918bf50058548f2421463ae09e1302be8e5b4b882c81c2edb8')
+
+
+def test_get_hd_channels():
+    channels = ['SCIM75YWRIU7G7B5JECYT44NQZDCL4IOQ7CXBWAQLMXQDTRVMNJMLXBA',
+                'SCA7Q4TB6QJZQQPTKHBSICPNJELIXSE66Z57ZAKWCZOBIQUXJLQVDW4W',
+                'SAG3ERPST7DW5FVSZN24QMFFHGSNPT7RRWCU4T4NX5LBBAE2BBNJNOKG',
+                'SBUDIZMRGW32OBWLM6BYU3QPF5ZSWT5YO6TX4Q3CWKLE6PFAMFQPCT43']
+
+    assert set(get_hd_channels('SC6WVXYFXJKG3SLAOYKZAPTQI5ZDKZ3JQNBZMCRZK4ZM3HYIRGRSBDPA','hello',4)) == set(channels)
+
+


### PR DESCRIPTION
Changed the way seeds are created.
The previous way to create a "KinAccount" had too many parameters and options.

Changes:

- Added "get_hd_channels" and "create_channels" methods.
- Channel secret keys must be passed to the KinAccount object.
- Created channels are now created in one multi-op transaction instead of 1 by 1
- Updated readme
