### PR TITLE
Handle multiple errors

### DIFF
--- a/kin/blockchain/errors.py
+++ b/kin/blockchain/errors.py
@@ -94,6 +94,7 @@ class OperationResultCode:
     BAD_AUTH = 'op_bad_auth'
     NO_ACCOUNT = 'op_no_source_account'
     NOT_SUPPORTED = 'op_not_supported'
+    SUCCESS = 'op_success'
 
 
 # noinspection PyClassHasNoInit

--- a/kin/errors.py
+++ b/kin/errors.py
@@ -213,7 +213,6 @@ def translate_operation_error(op_result_codes):
         if code != OperationResultCode.SUCCESS:
             op_result_code = code
             break
-    op_result_code = op_result_codes[0]
     if op_result_code == OperationResultCode.BAD_AUTH \
             or op_result_code == CreateAccountResultCode.MALFORMED \
             or op_result_code == PaymentResultCode.NO_ISSUER \

--- a/kin/errors.py
+++ b/kin/errors.py
@@ -208,7 +208,11 @@ def translate_transaction_error(tx_error):
 
 def translate_operation_error(op_result_codes):
     """Operation error translator."""
-    # NOTE: we currently handle only one operation per transaction!
+    # Find first failed op
+    for code in op_result_codes:
+        if code != OperationResultCode.SUCCESS:
+            op_result_code = code
+            break
     op_result_code = op_result_codes[0]
     if op_result_code == OperationResultCode.BAD_AUTH \
             or op_result_code == CreateAccountResultCode.MALFORMED \

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -129,7 +129,7 @@ def test_translate_operation_error():
     ]
 
     for fixture in fixtures:
-        err_dict['extras']['result_codes']['operations'] = [fixture[0]]
+        err_dict['extras']['result_codes']['operations'] = fixture[0]
         e = KinErrors.translate_horizon_error(HorizonError(err_dict))
         assert isinstance(e, fixture[1])
         assert e.error_code == fixture[0][-1]

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -122,7 +122,7 @@ def test_translate_operation_error():
         [[PaymentResultCode.NOT_AUTHORIZED], KinErrors.AccountNotActivatedError, 'account not activated', {}],
 
         # InternalError
-        [['unknown', KinErrors.InternalError], 'internal error', {'internal_error': 'unknown operation error'}],
+        [['unknown'], KinErrors.InternalError, 'internal error', {'internal_error': 'unknown operation error'}],
 
         # MultiOp
         [[OperationResultCode.SUCCESS, PaymentResultCode.UNDERFUNDED], KinErrors.LowBalanceError, 'low balance', {}]

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -98,37 +98,40 @@ def test_translate_operation_error():
 
     fixtures = [
         # RequestError
-        [OperationResultCode.BAD_AUTH, KinErrors.RequestError, 'bad request', {}],
-        [CreateAccountResultCode.MALFORMED, KinErrors.RequestError, 'bad request', {}],
-        [PaymentResultCode.NO_ISSUER, KinErrors.RequestError, 'bad request', {}],
-        [PaymentResultCode.LINE_FULL, KinErrors.RequestError, 'bad request', {}],
-        [ChangeTrustResultCode.INVALID_LIMIT, KinErrors.RequestError, 'bad request', {}],
+        [[OperationResultCode.BAD_AUTH], KinErrors.RequestError, 'bad request', {}],
+        [[CreateAccountResultCode.MALFORMED], KinErrors.RequestError, 'bad request', {}],
+        [[PaymentResultCode.NO_ISSUER], KinErrors.RequestError, 'bad request', {}],
+        [[PaymentResultCode.LINE_FULL], KinErrors.RequestError, 'bad request', {}],
+        [[ChangeTrustResultCode.INVALID_LIMIT], KinErrors.RequestError, 'bad request', {}],
 
         # AccountNotFoundError
-        [OperationResultCode.NO_ACCOUNT, KinErrors.AccountNotFoundError, 'account not found', {}],
-        [PaymentResultCode.NO_DESTINATION, KinErrors.AccountNotFoundError, 'account not found', {}],
+        [[OperationResultCode.NO_ACCOUNT], KinErrors.AccountNotFoundError, 'account not found', {}],
+        [[PaymentResultCode.NO_DESTINATION], KinErrors.AccountNotFoundError, 'account not found', {}],
 
         # AccountExistsError
-        [CreateAccountResultCode.ACCOUNT_EXISTS, KinErrors.AccountExistsError, 'account already exists', {}],
+        [[CreateAccountResultCode.ACCOUNT_EXISTS], KinErrors.AccountExistsError, 'account already exists', {}],
 
         # LowBalanceError
-        [CreateAccountResultCode.LOW_RESERVE, KinErrors.LowBalanceError, 'low balance', {}],
-        [PaymentResultCode.UNDERFUNDED, KinErrors.LowBalanceError, 'low balance', {}],
+        [[CreateAccountResultCode.LOW_RESERVE], KinErrors.LowBalanceError, 'low balance', {}],
+        [[PaymentResultCode.UNDERFUNDED], KinErrors.LowBalanceError, 'low balance', {}],
 
         # AccountNotActivatedError
-        [PaymentResultCode.SRC_NO_TRUST, KinErrors.AccountNotActivatedError, 'account not activated', {}],
-        [PaymentResultCode.NO_TRUST, KinErrors.AccountNotActivatedError, 'account not activated', {}],
-        [PaymentResultCode.SRC_NOT_AUTHORIZED, KinErrors.AccountNotActivatedError, 'account not activated', {}],
-        [PaymentResultCode.NOT_AUTHORIZED, KinErrors.AccountNotActivatedError, 'account not activated', {}],
+        [[PaymentResultCode.SRC_NO_TRUST], KinErrors.AccountNotActivatedError, 'account not activated', {}],
+        [[PaymentResultCode.NO_TRUST], KinErrors.AccountNotActivatedError, 'account not activated', {}],
+        [[PaymentResultCode.SRC_NOT_AUTHORIZED], KinErrors.AccountNotActivatedError, 'account not activated', {}],
+        [[PaymentResultCode.NOT_AUTHORIZED], KinErrors.AccountNotActivatedError, 'account not activated', {}],
 
         # InternalError
-        ['unknown', KinErrors.InternalError, 'internal error', {'internal_error': 'unknown operation error'}]
+        [['unknown', KinErrors.InternalError], 'internal error', {'internal_error': 'unknown operation error'}],
+
+        # MultiOp
+        [[OperationResultCode.SUCCESS, PaymentResultCode.UNDERFUNDED], KinErrors.LowBalanceError, 'low balance', {}]
     ]
 
     for fixture in fixtures:
         err_dict['extras']['result_codes']['operations'] = [fixture[0]]
         e = KinErrors.translate_horizon_error(HorizonError(err_dict))
         assert isinstance(e, fixture[1])
-        assert e.error_code == fixture[0]
+        assert e.error_code == fixture[0][-1]
         assert e.message == fixture[2]
         assert e.extra == fixture[3]


### PR DESCRIPTION
kin-SDK only ever translated the first operation in a horizon response.
Now it checks the first failed operation instead of the first operation, so if you have a transaction with 3 ops, 2 succeed but the last one fails, you will get the correct error.